### PR TITLE
Allow to build the library with static libgcc/libstdc++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,19 @@ option(BUILD_WITH_H264 "Enable OpenH264 encoder" ON)
 option(BUILD_RECORDER_WITH_SOUND "Build libopenglrecorder with sound recording support" ON)
 CMAKE_DEPENDENT_OPTION(BUILD_PULSE_WO_DL "If pulseaudio in your distro / system is optional, turn this off to load pulse with libdl"
     ON "BUILD_RECORDER_WITH_SOUND;UNIX" OFF)
+option(STATIC_RUNTIME_LIBS "Build with static runtime libraries" OFF)
 
 if (UNIX OR MINGW)
     if (CMAKE_BUILD_TYPE MATCHES Debug)
         add_definitions(-std=gnu++0x -O0)
     else()
         add_definitions(-std=gnu++0x -O3)
+    endif()
+endif()
+
+if (${STATIC_RUNTIME_LIBS})
+    if (UNIX OR MINGW)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -static-libgcc -static-libstdc++")
     endif()
 endif()
 


### PR DESCRIPTION
Useful mainly for mingw build.

It should be possible to allow static runtime for visual studio using /MT, but I didn't check it.

Actually you can ignore this pull request if you don't like it, but I need something like this for mingw build, so it would be easier for me to just use cmake flag rather than modifying CMakeLists.txt file.